### PR TITLE
clear() called after onComplete() crashes on a new project 

### DIFF
--- a/library/src/main/java/com/dpizarro/pinview/library/PinView.java
+++ b/library/src/main/java/com/dpizarro/pinview/library/PinView.java
@@ -176,7 +176,7 @@ public class PinView extends PinViewBaseHelper {
     public void clear() {
 
         for (int i = 0; i < mNumberPinBoxes; i++) {
-            getPinBox(i).getText().clear();
+            getPinBox(i).setText("");
         }
         checkPinBoxesAvailableOrder();
     }


### PR DESCRIPTION
This is strange, but calling clear() after onComplete() crashes the project with an IndexOutOfBoundsException in setSpan (0 ... 1). The crash is in Android code (not the library) and seems like Android assumes that the field is not null (or it hasn't updated the length). I've seen some more cases in the internet.

It happens in a LG G2 and a emulator with a Nexus 5. I can send you an empty project with the code to test the issue if you need it.
